### PR TITLE
Refactor ToC and CSS for nested two column lists

### DIFF
--- a/_pages/index.html
+++ b/_pages/index.html
@@ -18,20 +18,36 @@ layout: null
     <main id="main" role="main">
       <div class="wrapper">
 
-      <ol>{% for nav in site.navigation %}
-        {% if nav.url == nil %}{% continue %}{% endif %}
-        <li><h1 id="{{ nav.url | remove:"/" }}">{{ nav.text }}</h1>
-          {% if nav.blurb %}<p>{{ nav.blurb }}</p>{% endif %}
-          <ol>{% for child in nav.children %}
-            {% if child.children != nil %}
-              <li id="{{ child.text | slugify }}" class="{{ child.text | slugify }}">{{ child.text }}
-            {% else %}
-              <li class="{{ child.text | slugify }}"><a href="{{ site.baseurl }}/{{ child.url }}">{{ child.text }}</a>{% endif %}
-              <ol>{% for grandchild in child.children %}
-                <li class="{{ grandchild.text | slugify }}"><a href="{{ site.baseurl }}/{{ grandchild.url }}">{{ grandchild.text }}</a></li>
-                {% endfor %}</ol></li>{% endfor %}</ol>
-        </li>
-      {% endfor %}
+      <ol>
+        {% for nav in site.navigation %}
+          {% if nav.url == nil %}{% continue %}{% endif %}
+          <li>
+            <h1 id="{{ nav.url | remove:"/" }}">{{ nav.text }}</h1>
+            {% if nav.blurb %}<p>{{ nav.blurb }}</p>{% endif %}
+
+            {% unless nav.children == nil %}
+              <ol class="toc-nav-children">
+                {% for child in nav.children %}
+                  {% if child.children != nil %}
+                  <li id="{{ child.text | slugify }}" class="toc-nav-child-with-children {{ child.text | slugify }}">
+                    {{ child.text }}
+                    <ol class="toc-nav-grandchildren">
+                      {% for grandchild in child.children %}
+                        <li class="{{ grandchild.text | slugify }}">
+                          <a href="{{ site.baseurl }}/{{ grandchild.url }}">{{ grandchild.text }}</a>
+                        </li>
+                      {% endfor %}
+                    </ol>
+                  {% else %}
+                  <li class="{{ child.text | slugify }}">
+                    <a href="{{ site.baseurl }}/{{ child.url }}">{{ child.text }}</a>
+                  {% endif %}
+                  </li>
+                {% endfor %}
+              </ol>
+            {% endunless %}
+          </li>
+        {% endfor %}
       </ol>
       </div>
     </main>

--- a/stylesheets/screen.css
+++ b/stylesheets/screen.css
@@ -1135,33 +1135,22 @@ a[id]{
 }
 
 @media screen and (min-width: 711.11px){
-	.layout-table-of-contents .wrapper ol li.tools{ clear: both; }
+	.toc-nav-children {
+  	clear: both;
+  	-webkit-column-count: 2;
+  	-moz-column-count: 2;
+  	column-count: 2;
+  }
 
-	.layout-table-of-contents .wrapper ol li.classes > ol,
-	.layout-table-of-contents .wrapper ol li.equipment  > ol,
-	.layout-table-of-contents .wrapper ol li.networks  > ol,
-	.layout-table-of-contents .wrapper ol li.offices  > ol,
-	.layout-table-of-contents .wrapper ol h1#policies + p + ol,
-	.layout-table-of-contents .wrapper ol li.teams  > ol,
-	.layout-table-of-contents .wrapper ol li.tools  > ol{
-	clear: both;
-	-webkit-column-count: 2;
-	-moz-column-count: 2;
-	column-count: 2;
-}
+  .toc-nav-child-with-children {
+    column-span: all;
+  }
 
-	.layout-table-of-contents .wrapper ol li.classes::after,
-	.layout-table-of-contents .wrapper ol li.equipment::after,
-	.layout-table-of-contents .wrapper ol li.networks::after,
-	.layout-table-of-contents .wrapper ol li.offices::after,
-	.layout-table-of-contents .wrapper ol li.overview::after,
-	.layout-table-of-contents .wrapper ol li.policies::after,
-	.layout-table-of-contents .wrapper ol li.teams::after,
-	.layout-table-of-contents .wrapper ol li.tools::after{
-		display: table;
-		content: "";
-		clear: both;
-	}
+  .toc-nav-grandchildren {
+    -webkit-column-count: 2;
+    -moz-column-count: 2;
+    column-count: 2;
+  }
 }
 
 .layout-table-of-contents ol h1{


### PR DESCRIPTION
Refactors `_pages/index.html` and `stylesheets/screen.css` to:

1. Enhance readability of `index.html`
2. Implement consistent two-column list layout even though lists are nested.

Current live site example:
![screen shot 2016-07-26 at 1 59 17 pm](https://cloud.githubusercontent.com/assets/2487968/17151228/e98c6d5a-5340-11e6-9a68-4695453ef2bb.png)

Previous commit to fix #4:
![screen shot 2016-07-26 at 2 00 25 pm](https://cloud.githubusercontent.com/assets/2487968/17151245/fbb31948-5340-11e6-87c5-76b5aa6648d5.png)

This merge:
![screen shot 2016-07-26 at 2 54 13 pm](https://cloud.githubusercontent.com/assets/2487968/17151251/04787fd2-5341-11e6-8b8a-8a3b00e761f9.png)

